### PR TITLE
feat: Add navbar

### DIFF
--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,0 +1,112 @@
+import React, { ReactElement } from "react";
+import styled, { css } from "styled-components";
+import { Heading1, Text } from "../../typography";
+
+export interface NavbarOption {
+  value: string;
+  label: string;
+  icon: ReactElement;
+}
+
+export interface NavbarProps {
+  options: NavbarOption[];
+  logo: ReactElement;
+  title: string;
+  selected: string;
+  setSelected: (option: string) => void;
+}
+
+export const Navbar = ({
+  options,
+  logo,
+  title,
+  selected,
+  setSelected,
+  ...props
+}: NavbarProps): ReactElement | null => {
+  return (
+    <NavbarContainer {...props}>
+      <NavbarHeading>
+        <NavElemIcon>{React.cloneElement(logo)}</NavElemIcon>
+        <StyledHeading1 bold>{title}</StyledHeading1>
+      </NavbarHeading>
+      <NavbarMenu>
+        {options.map((option) => (
+          <div key={option.value} onClick={() => setSelected(option.value)}>
+            <StyledMenuItem active={selected === option.value}>
+              <NavElemIcon>{React.cloneElement(option.icon)}</NavElemIcon>
+              <NavElemText>{option.label}</NavElemText>
+            </StyledMenuItem>
+          </div>
+        ))}
+      </NavbarMenu>
+    </NavbarContainer>
+  );
+};
+
+const NavbarContainer = styled.aside`
+  width: 10rem;
+  min-width: 10rem;
+  padding-top: 1.5rem;
+`;
+
+const StyledHeading1 = styled(Heading1)`
+  color: ${({ theme }) => theme.colors.primary};
+  text-transform: lowercase;
+`;
+
+const NavbarMenu = styled.nav`
+  margin-top: 3rem;
+  & > div {
+    margin-bottom: 1rem;
+  }
+  & > div:last-child {
+    margin-bottom: 0rem;
+  }
+`;
+
+const NavElemIcon = styled.div``;
+
+const NavElemText = styled(Text)``;
+
+const NavbarHeading = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  & > ${NavElemIcon} {
+    margin-right: 1rem;
+  }
+`;
+
+const StyledMenuItem = styled.div<{ active: boolean }>`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  & > ${NavElemIcon} {
+    margin-right: 1rem;
+  }
+  & > ${NavElemIcon}, & > ${NavElemText} {
+    color: ${({ theme }) => theme.colors.texts};
+    transition-property: color;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 150ms;
+    padding: 0.25rem 0;
+  }
+  ${({ active }) =>
+    !active &&
+    css`
+      cursor: pointer;
+      &:hover > ${NavElemIcon}, &:hover > ${NavElemText} {
+        color: ${({ theme }) => `${theme.colors.primary}CC`};
+        text-opacity: 0.9;
+      }
+    `}
+  ${({ active }) =>
+    active &&
+    css`
+      cursor: default;
+      & > ${NavElemIcon}, & > ${NavElemText} {
+        color: ${({ theme }) => theme.colors.primary};
+      }
+    `}
+`;

--- a/src/components/Navbar/index.ts
+++ b/src/components/Navbar/index.ts
@@ -1,0 +1,1 @@
+export * from "./Navbar";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,3 +6,4 @@ export * from "./Card";
 export * from "./BoxVaultAPY";
 export * from "./Dropdown";
 export * from "./Spinner";
+export * from "./Navbar";

--- a/stories/components/Navbar.stories.tsx
+++ b/stories/components/Navbar.stories.tsx
@@ -1,0 +1,126 @@
+import React, { ReactElement } from "react";
+import { ComponentMeta } from "@storybook/react";
+import {
+  Navbar as NavbarComponent,
+  Icon as IconComponent,
+  NavbarOption,
+  NavbarProps,
+} from "../../src";
+
+const options: NavbarOption[] = [
+  {
+    value: "portfolio",
+    label: "Portfolio",
+    icon: <IconComponent.Wallet />,
+  },
+  {
+    value: "vaults",
+    label: "Vaults",
+    icon: <IconComponent.Vault />,
+  },
+  {
+    value: "labs",
+    label: "Labs",
+    icon: <IconComponent.Lab />,
+  },
+  {
+    value: "ironBank",
+    label: "Iron Bank",
+    icon: <IconComponent.IronBank />,
+  },
+  {
+    value: "settings",
+    label: "Settings",
+    icon: <IconComponent.Settings />,
+  },
+];
+
+const watchOptions: NavbarOption[] = [
+  {
+    value: "query",
+    label: "Query",
+    icon: <IconComponent.Lab />,
+  },
+  {
+    value: "risk",
+    label: "Risk",
+    icon: <IconComponent.Error />,
+  },
+  {
+    value: "report",
+    label: "Report",
+    icon: <IconComponent.Info />,
+  },
+];
+
+export default {
+  title: "Components/Navbar",
+  component: NavbarComponent,
+} as ComponentMeta<typeof NavbarComponent>;
+
+function YearnLogo(): ReactElement {
+  return (
+    <svg
+      width={"32"}
+      height={"32"}
+      viewBox={"0 0 32 32"}
+      fill={"none"}
+      xmlns={"http://www.w3.org/2000/svg"}
+    >
+      <path
+        fillRule={"evenodd"}
+        clipRule={"evenodd"}
+        d={
+          "M32 16C32 13.9059 31.5834 11.8118 30.7821 9.87712C29.9808 7.9424 28.7946 6.16704 27.3136 4.6864C25.833 3.20544 24.0576 2.0192 22.1229 1.21792C20.1882 0.41664 18.0941 0 16 0C13.9059 0 11.8118 0.41664 9.87712 1.21792C7.9424 2.0192 6.16704 3.20544 4.6864 4.6864C3.20544 6.16704 2.0192 7.9424 1.21792 9.87712C0.41664 11.8118 0 13.9059 0 16C0 18.0941 0.41664 20.1882 1.21792 22.1229C2.0192 24.0576 3.20544 25.833 4.6864 27.3136C6.16704 28.7946 7.9424 29.9808 9.87712 30.7821C11.8118 31.5834 13.9059 32 16 32C18.0941 32 20.1882 31.5834 22.1229 30.7821C24.0576 29.9808 25.833 28.7946 27.3136 27.3136C28.7946 25.833 29.9808 24.0576 30.7821 22.1229C31.5834 20.1882 32 18.0941 32 16Z"
+        }
+        fill={"#0657F9"}
+      />
+      <path
+        d={
+          "M14.2345 15.5725V13.8458C12.9081 13.1933 11.9948 11.8282 11.9948 10.25C11.9948 8.03875 13.7881 6.24547 15.9999 6.24547C18.4834 6.24547 20.2767 8.03875 20.2767 10.25C20.2767 10.8074 20.1621 11.3383 19.8873 11.969L19.181 9.67299L17.7653 10.1156L19.0207 14.8938L23.8943 13.1008L23.302 11.7034L21.4844 12.3255C21.8133 11.6122 21.878 11.0877 21.878 10.25C21.878 7.15363 19.3679 4.64355 15.9999 4.64355C12.9036 4.64355 10.3935 7.15363 10.3935 10.25C10.3935 12.7293 12.0034 14.8327 14.2345 15.5725Z"
+        }
+        fill={"white"}
+      />
+      <path
+        d={"M15.173 8.77576H16.8267V23.2244H15.173V8.77576Z"}
+        fill={"white"}
+      />
+      <path
+        d={
+          "M17.7653 18.1543V16.4276C19.9963 17.1675 21.6063 19.2708 21.6063 21.7502C21.6063 24.8465 19.0962 27.3566 15.9999 27.3566C12.6319 27.3566 10.1218 24.8465 10.1218 21.7502C10.1218 20.9124 10.1864 20.3879 10.5154 19.6747L8.69779 20.2967L8.10547 18.8996L12.9791 17.1063L14.2344 21.8846L12.8187 22.3271L12.1125 20.0311C11.8376 20.6619 11.7231 21.1927 11.7231 21.7502C11.7231 23.9614 13.5163 25.7547 15.9999 25.7547C18.2117 25.7547 20.005 23.9614 20.005 21.7502C20.005 20.1719 19.0917 18.8071 17.7653 18.1543Z"
+        }
+        fill={"white"}
+      />
+    </svg>
+  );
+}
+
+export const Navbar = (args: NavbarProps): ReactElement => {
+  const [selected, setSelected] = React.useState<string>("vaults");
+  const [selectedWatch, setSelectedWatch] = React.useState<string>("query");
+
+  return (
+    <div style={{ display: "flex", flexDirection: "row" }}>
+      <NavbarComponent
+        {...args}
+        selected={selected}
+        setSelected={setSelected}
+        options={options}
+        title={"yearn"}
+        logo={<YearnLogo />}
+      />
+      <NavbarComponent
+        {...args}
+        selected={selectedWatch}
+        setSelected={setSelectedWatch}
+        options={watchOptions}
+        title={"watch"}
+        logo={<YearnLogo />}
+      />
+    </div>
+  );
+};
+
+Navbar.args = {
+  defaultOption: options[0],
+};


### PR DESCRIPTION
Create the default structure for the Navbar.
- [x] The Navbar is the left block used to navigation between pages. It is set as `aside`.
- [x] The Navbar is a `nav` html
- [x] The logo and the title can be change via some props
- [x] Each element is composed of one label/value pair and one logo
- [x] Transition between colors are smooth

**Notes**
- Responsive, as for the other components right now, is not defined yet
- Width of the navbar is fixed to `160px`